### PR TITLE
Made the anaconda upload workflow depend of the test workflow

### DIFF
--- a/.github/workflows/anaconda_upload.yml
+++ b/.github/workflows/anaconda_upload.yml
@@ -6,10 +6,15 @@ on:
       - main
     tags:
       - '*'
+  workflow_run:
+    workflows: ["Test"]
+    types:
+      - completed
 
 jobs:
   anaconda_org_build_and_upload:
     name: anaconda.org upload py${{ matrix.python-version }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
As titled, this PR intends to make the `anaconda-upload` CI workflow to depend upon the completion of the `Test` workflow.