### PR TITLE
Switch all embedded DSO handling to use mkstemp.

### DIFF
--- a/pixie/compiler.py
+++ b/pixie/compiler.py
@@ -16,8 +16,7 @@ from pixie.targets.common import Features, TargetDescription
 from pixie.codegen_helpers import (Codegen, Context, IRGenerator,
                                    module_pass_manager, function_pass_manager)
 from pixie.platform import Toolchain
-from pixie.dso_tools import (ElfMapper, shmEmbeddedDSOHandler,  # noqa: F401
-                             mkstempEmbeddedDSOHandler)  # noqa: F401
+from pixie.dso_tools import ElfMapper, mkstempEmbeddedDSOHandler
 from pixie.mcext import c
 from pixie.overlay_injectors import (AddPixieDictGenerator,
                                      AugmentingPyInitGenerator)
@@ -26,9 +25,8 @@ from pixie import llvm_types as lt
 
 IS_LINUX = sys.platform.startswith('linux')
 
-# TODO: fix for x-compile
-defaultDSOHandler = (shmEmbeddedDSOHandler if IS_LINUX
-                     else mkstempEmbeddedDSOHandler)
+
+defaultDSOHandler = mkstempEmbeddedDSOHandler
 
 
 class SimpleCompiler():

--- a/pixie/tests/test_selectors.py
+++ b/pixie/tests/test_selectors.py
@@ -1,10 +1,6 @@
 from pixie.targets import x86_64, arm64
 from pixie.targets.common import Features
-from pixie.dso_tools import (
-    ElfMapper,
-    shmEmbeddedDSOHandler,
-    mkstempEmbeddedDSOHandler,
-)
+from pixie.dso_tools import ElfMapper, mkstempEmbeddedDSOHandler
 from pixie.mcext import c
 from pixie.selectors import PyVersionSelector
 from pixie.targets.x86_64 import x86CPUSelector
@@ -107,7 +103,7 @@ class TestSelectors(PixieTestCase):
         expected, dispatch_data = self.gen_dispatch_and_expected(dispatch_keys)
 
         selector_class = x86CPUSelector
-        dso_handler = shmEmbeddedDSOHandler()
+        dso_handler = mkstempEmbeddedDSOHandler()
         llvm_ir = self.gen_mod(dispatch_data, selector_class, dso_handler)
 
         # Compile into DSO


### PR DESCRIPTION
This switches all internal use of shm based embedded DSO handling to mkstemp based embedded DSO handling. An issue was identified in testing where a /dev/shm mount could have the `noexec` flag set (seemingly quite common in docker containers) and as a result of this embedded DSOs extracted to this location could not be executed. Resolving this will take some time and so as a temporary measure the aforementioned switch is being made.